### PR TITLE
feat: integrate Discord webhook for new challenge notifications

### DIFF
--- a/app/api/problems/route.ts
+++ b/app/api/problems/route.ts
@@ -7,6 +7,7 @@ import userSchema from "@/models/userSchema";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/authOptions";
 import UserQuestionModel from "@/models/userQuestionSchema";
+import { sendDiscordNotification } from "@/utlis/discordNotifier";
 export const runtime = "nodejs";
 
 export async function POST(req: NextRequest) {
@@ -40,6 +41,18 @@ export async function POST(req: NextRequest) {
       body.description
     ) {
       const product = await QuestionModel.create(body);
+      await product.save();
+      const challengeLink = `https://flagforge.xyz/problems/${product._id}`;
+
+      // Send Discord notification
+      await sendDiscordNotification(
+        "🧩 New Challenge Released!",
+        body.description,
+        "NEW_CHALLENGE",
+        body.points,
+        body.category,
+        challengeLink
+      );
 
       return NextResponse.json(
         { success: true, message: "Your qustion has been created" },

--- a/utlis/discordNotifier.ts
+++ b/utlis/discordNotifier.ts
@@ -1,0 +1,61 @@
+const DISCORD_WEBHOOK_URL = process.env.DISCORD_WEBHOOK_URL;
+
+const COLORS = {
+  NEW_CHALLENGE: 0x2ecc71, // green
+};
+
+export async function sendDiscordNotification(
+  title: string,
+  description: string,
+  type: "NEW_CHALLENGE" = "NEW_CHALLENGE",
+  points?: number,
+  category?: string,
+  link?: string
+) {
+  if (!DISCORD_WEBHOOK_URL) {
+    console.error("❌ DISCORD_WEBHOOK_URL not set");
+    return;
+  }
+
+  const payload = {
+    embeds: [
+      {
+        title,
+        description,
+        color: COLORS[type],
+        timestamp: new Date().toISOString(),
+        footer: { text: "FlagForge System" },
+        fields: [
+          ...(category
+            ? [{ name: "Category", value: category, inline: true }]
+            : []),
+          ...(points !== undefined
+            ? [{ name: "Points", value: points.toString(), inline: true }]
+            : []),
+          ...(link
+            ? [
+                {
+                  name: "Challenge Link",
+                  value: `[Click here](${link})`,
+                  inline: false,
+                },
+              ]
+            : []),
+        ],
+      },
+    ],
+  };
+
+  try {
+    const res = await fetch(DISCORD_WEBHOOK_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    if (!res.ok)
+      console.error(`❌ Failed to send Discord message: ${res.statusText}`);
+  } catch (err) {
+    console.error("⚠️ Error sending Discord message:", err);
+  }
+}


### PR DESCRIPTION
- Added structured Discord embed notifications when a new challenge is created
- Includes title, description, category, points, and direct challenge link
- Uses default webhook name and avatar from Discord channel settings
- Ensures real-time alerts for community on #new-challenges channel