### PR TITLE
Potential fix for code scanning alert no. 5: Server-side request forgery

### DIFF
--- a/app/api/instagram/image/route.ts
+++ b/app/api/instagram/image/route.ts
@@ -11,6 +11,38 @@ const isAllowedHost = (hostname: string) => {
     );
 };
 
+const isAllowedImageUrl = (url: URL) => {
+    return url.protocol === "https:" && isAllowedHost(url.hostname);
+};
+
+const fetchWithValidatedRedirects = async (
+    initialUrl: URL,
+    maxRedirects = 5
+): Promise<Response> => {
+    let currentUrl = initialUrl;
+
+    for (let i = 0; i <= maxRedirects; i++) {
+        if (!isAllowedImageUrl(currentUrl)) {
+            throw new Error("Invalid redirect host");
+        }
+
+        const response = await fetch(currentUrl.toString(), { redirect: "manual" });
+
+        if (response.status >= 300 && response.status < 400) {
+            const location = response.headers.get("location");
+            if (!location) {
+                throw new Error("Redirect missing location");
+            }
+            currentUrl = new URL(location, currentUrl);
+            continue;
+        }
+
+        return response;
+    }
+
+    throw new Error("Too many redirects");
+};
+
 export async function GET(request: Request) {
     const { searchParams } = new URL(request.url);
     const src = searchParams.get("src");
@@ -31,7 +63,7 @@ export async function GET(request: Request) {
     }
 
     try {
-        const response = await fetch(url.toString(), { redirect: "follow" });
+        const response = await fetchWithValidatedRedirects(url);
         if (!response.ok) {
             return NextResponse.json({ error: "Failed to fetch image" }, { status: 502 });
         }


### PR DESCRIPTION
Potential fix for [https://github.com/FlagForgeCTF/flagForge/security/code-scanning/5](https://github.com/FlagForgeCTF/flagForge/security/code-scanning/5)

General fix: keep user-controlled URL usage constrained by strict allowlisting not only for the initial URL, but also for any redirect target. The safest minimal approach is to disable automatic redirect following and manually process redirects with re-validation on each hop.

Best fix here (without changing intended functionality of “following redirects”): in `app/api/instagram/image/route.ts`, replace the single `fetch(..., { redirect: "follow" })` with a small helper that:
- uses `redirect: "manual"`,
- validates protocol/host for each URL before requesting,
- if response is redirect (`3xx` + `Location`), resolves next URL relative to current URL, re-validates it, and continues up to a bounded redirect count,
- returns the final non-redirect response.

Needed changes:
- Add a helper function (e.g., `fetchWithValidatedRedirects`) above `GET`.
- Update line 34 call site to use this helper.
- No new imports/dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
